### PR TITLE
added LanguageBadge component with known/learning variant styles

### DIFF
--- a/client/src/components/LanguageBadge.module.css
+++ b/client/src/components/LanguageBadge.module.css
@@ -1,0 +1,34 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  font-size: 0.78rem;
+  font-weight: 500;
+  transition: transform var(--transition-fast);
+  cursor: default;
+}
+
+.badge:hover {
+  transform: scale(1.03);
+}
+
+.known {
+  background: var(--color-secondary-50);
+  color: var(--color-secondary-dark);
+}
+
+.learning {
+  background: var(--color-warning-50);
+  color: #92400e;
+}
+
+.lang {
+  font-weight: 600;
+}
+
+.level {
+  opacity: 0.8;
+  font-size: 0.72rem;
+}

--- a/client/src/components/LanguageBadge.tsx
+++ b/client/src/components/LanguageBadge.tsx
@@ -1,0 +1,16 @@
+import styles from "./LanguageBadge.module.css";
+
+interface Props {
+  language: string;
+  proficiency: string;
+  variant?: "known" | "learning";
+}
+
+export default function LanguageBadge({ language, proficiency, variant = "known" }: Props) {
+  return (
+    <span className={`${styles.badge} ${styles[variant]}`}>
+      <span className={styles.lang}>{language}</span>
+      <span className={styles.level}>{proficiency}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

What does this PR change?
Added a reusable LanguageBadge component to display a user’s language and proficiency level. This includes the known and learning variant styles.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / refactor
- [ ] Documentation
- Note: If you have a security concern please reach out privately

## How to review
- Review the LanguageBadge component implementation
- Verify variant styling for both known and learning
- Ensure that language, proficiency, and variants are handled correctly

## Testing

- [ ] Not applicable yet
- [x] Manual testing (describe)
  - Render the component and verify the correct display of language and proficiency 
  - Confirm styling changes based on variant
- [ ] Automated tests (describe)

## Checklist

- [x] I kept this PR small and focused
- [x] I self-reviewed my changes
- [x] I updated docs/comments if needed