### PR TITLE
fixed welcome back vs welcome

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -18,6 +18,16 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [connectedIds, setConnectedIds] = useState<Set<string>>(new Set());
+  const [isFirstVisit, setIsFirstVisit] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    const key = `visited_${user._id}`;
+    if (!localStorage.getItem(key)) {
+      localStorage.setItem(key, "1");
+      setIsFirstVisit(true);
+    }
+  }, [user]);
 
   useEffect(() => {
     api
@@ -27,6 +37,7 @@ export default function Dashboard() {
       .finally(() => setLoading(false));
   }, []);
 
+  // sends a match request to the api and marks that user as connected in local state
   const handleConnect = async (userId: string) => {
     setConnectingId(userId);
     try {
@@ -39,6 +50,7 @@ export default function Dashboard() {
     }
   };
 
+  // true when the user has at least one known language and a bio filled in
   const profileComplete = user && user.knownLanguages.length > 0 && user.bio;
 
   return (
@@ -49,7 +61,7 @@ export default function Dashboard() {
           {/* Welcome banner */}
           <section className={styles.welcome}>
             <div className={styles.welcomeContent}>
-              <h1 className={styles.welcomeTitle}>Welcome back, {user?.firstName}</h1>
+              <h1 className={styles.welcomeTitle}>{isFirstVisit ? "Welcome" : "Welcome back"}, {user?.firstName}</h1>
               <p className={styles.welcomeSubtitle}>
                 Discover language partners matched to your goals
               </p>


### PR DESCRIPTION
## Summary

- For first time user, the message says "Welcome" and for users logging back in, it says "Welcome Back"

## Related Issue(s)

Closes #69

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Chore / refactor
- [ ] Documentation
- Note: If you have a security concern please reach out privately

## How to review

- Look over code. 

## Testing

- [ ] Not applicable yet
- [x] Manual testing (describe)
Create an account fully and check that the home page says "Welcome". Log out and log back in and check that it says "Welcome Back"
- [ ] Automated tests (describe)

## Checklist

- [x] I kept this PR small and focused
- [x] I self-reviewed my changes
- [x] I updated docs/comments if needed